### PR TITLE
Make tests work on older Django versions

### DIFF
--- a/tests/data/example.py
+++ b/tests/data/example.py
@@ -7,6 +7,7 @@ class User:
     """
     Quacks just enough like a Django model for the tests to work
     """
+
     class Manager:
         def all(self):
             return self


### PR DESCRIPTION
Fixes:

```
env/lib/python3.9/site-packages/django/db/models/query.py:1486: in __init__
    if queryset is not None and not issubclass(queryset._iterable_class, ModelIterable):
E   AttributeError: 'Manager' object has no attribute '_iterable_class
```